### PR TITLE
Update code to use gitleaks v8.18.4 instead of latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Below you can find an example of the Slack notification:
 Following are the prerequisites to be met once before you begin:
 
 - Following packages are installed on your system:
-   - In case of Linux, install the following packages using either `./installation/linux_install_packages.sh` script or manually:
+   - In case of Linux, install the following packages by running either `./installation/linux_install_packages.sh` command or by installing them manually:
       - `git`
       - `jq`
       - `bash`
@@ -64,7 +64,7 @@ Following are the prerequisites to be met once before you begin:
          - Using `pip`
       - `requests`
          - Using `pip`
-   - In case of macOS, install the following packages using either `./installation/macos_install_packages.sh` script or manually:
+   - In case of macOS, install the following packages by running either `./installation/macos_install_packages.sh` command or by installing them manually:
       - `git`
       - `jq`
       - `bash`

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,66 @@
+# configuration file for git-cliff (0.1.0)
+
+[changelog]
+# changelog header
+header = """
+# Changelog\n
+All notable changes to this project will be documented in this file.\n
+"""
+# template for the changelog body
+# https://tera.netlify.app/docs/#introduction
+body = """
+{% set github_project_url = "https://github.com/abdullahkhawer/find-and-report-secrets-in-code/releases" %}
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}\n
+    [{{ version | trim_start_matches(pat="v") }}]: {{ github_project_url }}/tag/{{ version }}
+{% else %}\
+    ## [unreleased]\n
+    [unreleased]: {{ github_project_url }}/-/blob/master/CHANGELOG.md
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }}\
+    {% endfor %}
+{% endfor %}
+"""
+# remove the leading and trailing whitespace from the template
+trim = true
+
+[git]
+# parse the commits based on https://www.conventionalcommits.org
+conventional_commits = true
+# filter out the commits that are not conventional
+filter_unconventional = true
+# process each line of a commit as an individual commit
+split_commits = false
+# regex for preprocessing the commit messages
+commit_preprocessors = [
+    { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](https://github.com/orhun/git-cliff/issues/${2}))"},
+]
+# regex for parsing and grouping commits
+commit_parsers = [
+    { message = "^feat", group = "Features"},
+    { message = "^fix", group = "Bug Fixes"},
+    { message = "^doc", group = "Documentation"},
+    { message = "^perf", group = "Performance"},
+    { message = "^refactor", group = "Refactor"},
+    { message = "^style", group = "Styling"},
+    { message = "^test", group = "Testing"},
+    { message = "^chore\\(release\\):", skip = true},
+    { message = "^chore", group = "Miscellaneous Tasks"},
+    { message = "^ci", group = "CI"},
+    { body = ".*security", group = "Security"},
+]
+# filter out the commits that are not matched by commit parsers
+filter_commits = false
+# glob pattern for matching git tags
+tag_pattern = "v[0-9]*"
+# regex for skipping tags
+skip_tags = "v0.1.0-beta.1"
+# regex for ignoring tags
+ignore_tags = ""
+# sort the tags chronologically
+date_order = false
+# sort the commits inside sections by oldest/newest order
+sort_commits = "oldest"

--- a/docker/README.md
+++ b/docker/README.md
@@ -132,6 +132,9 @@ The variables referred using `$` are supposed to be created on the repository un
 
 The image used in this GitLab CI job is built using the Dockerfile that is present in a repository here: `https://github.com/abdullahkhawer/find-and-report-secrets-in-code/blob/master/docker/Dockerfile`
 
+An example of build command is below:
+`docker buildx build --platform linux/amd64 -t "abdullahkhawer/find-and-report-secrets-in-code:latest" --no-cache -f ./docker/Dockerfile .`
+
 The image used is this one which is publicly available.
 
 ## Notes

--- a/installation/linux_install_packages.sh
+++ b/installation/linux_install_packages.sh
@@ -12,9 +12,11 @@ git --version && jq --version && bash --version && make --version && wget --vers
 pip install atlassian-python-api pytz requests --break-system-packages
 
 # install Gitleaks
-rm -rf /usr/local/gitleaks && git clone https://github.com/gitleaks/gitleaks.git /usr/local/gitleaks
+sudo rm -rf /usr/local/gitleaks && sudo git clone https://github.com/gitleaks/gitleaks.git /usr/local/gitleaks
 cd /usr/local/gitleaks
-make build
+git config --global --add safe.directory /usr/local/gitleaks
+sudo git checkout tags/v8.18.4
+sudo make build
 cd /
 export PATH=$PATH:/usr/local/gitleaks
 echo -n "gitleaks " && gitleaks version

--- a/installation/macos_install_packages.sh
+++ b/installation/macos_install_packages.sh
@@ -1,11 +1,21 @@
 #!/bin/bash
 set -ex
 
-# install Git, jq, Bash, pip, Python3, Gitleaks
-brew install git jq bash python python@3 gitleaks
-git --version && jq --version && bash --version && pip --version && python3 --version && echo -n "gitleaks " && gitleaks version
+# install Git, jq, Bash, pip, Python3
+brew install git jq bash python python@3
+git --version && jq --version && bash --version && pip --version && python3 --version
 
 # install "Python Atlassian REST API Wrapper", "World timezone definitions, modern and historical" and "Requests" Python libraries
 pip install atlassian-python-api pytz requests || pip install atlassian-python-api pytz requests --break-system-packages
+
+# install Gitleaks
+sudo rm -rf /usr/local/gitleaks && sudo git clone https://github.com/gitleaks/gitleaks.git /usr/local/gitleaks
+cd /usr/local/gitleaks
+git config --global --add safe.directory /usr/local/gitleaks
+sudo git checkout tags/v8.18.4
+sudo make build
+cd /
+export PATH=$PATH:/usr/local/gitleaks
+echo -n "gitleaks " && gitleaks version
 
 echo "Installation completed successfully."


### PR DESCRIPTION
Changes:
- fix: Update code to use gitleaks v8.18.4 instead of latest and update the READMEs accordingly.
- chore: Add cliff.toml to be able to update CHANGELOG.md using git-cliff.